### PR TITLE
fix(interoperability): Add table with supported model elements

### DIFF
--- a/rhino-plugin/interoperability/rhino-import-export.md
+++ b/rhino-plugin/interoperability/rhino-import-export.md
@@ -14,9 +14,39 @@ There are two modes to open the file formats above.
 * [Import OpenStudio Model \(OSM\)](import/osm.md)
 * [Import Input Data File \(IDF\)](import/idf.md)
 
+There is no loss of information when importing HBJSON but only certain model elements
+can be imported from OSM, gbXML and IDF. These are summarized below.
+
+| Model Element                  | HBJSON     | OSM                    | gbXML                  | IDF                      |
+| ------------------------------ | ---------- | ---------------------- | ---------------------- | ------------------------ |
+| Geometry                       |  &#x2611;  |  &#x2611; <sup>1</sup> |  &#x2611; <sup>1</sup> |  &#x2611; <sup>1 2</sup> |
+| Spaces / Zoning                |  &#x2611;  |  &#x2611;              |  &#x2611;              |  &#x2611;                |
+| Boundary Conditions            |  &#x2611;  |  &#x2611;              |  &#x2611;              |  &#x2611;                |
+| Face Types (eg. AirBoundary)   |  &#x2611;  |  &#x2611;              |  &#x2611;              |  &#x2611;                |
+| Opaque Constructions           |  &#x2611;  |  &#x2611;              |  &#x2611;              |  &#x2611;                |
+| Window Constructions           |  &#x2611;  |  &#x2611; <sup>3</sup> |  &#x2611; <sup>3</sup> |  &#x2611; <sup>3</sup>   |
+| Schedules                      |  &#x2611;  |  &#x2611; <sup>4</sup> |  :x: <sup>5</sup>      |  :x: <sup>5</sup>        |
+| Space Types                    |  &#x2611;  |  WIP                   |  :x:                   |  :x:                     |
+| Thermostats + Outdoor Air Req. |  &#x2611;  |  WIP <sup>6</sup>      |  :x:                   |  :x:                     |
+| HVAC Systems                   |  &#x2611;  |  :x:                   |  :x:                   |  :x:                     |
+| SHW Systems                    |  &#x2611;  |  :x:                   |  :x:                   |  :x:                     |
+| Natural Ventilation            |  &#x2611;  |  :x:                   |  :x:                   |  :x:                     |
+| Everything Else                |  &#x2611;  |  :x:                   |  :x:                   |  :x:                     |
+
+<sup>1</sup> Formats do not natively support geometries with holes (they are collapsed to a single list of inward-turning vertices on export).<br>
+<sup>2</sup> IDF only supports Apertures/Doors with 3-4 vertices (more complex window geometries are triangulated upon export).<br>
+<sup>3</sup> No dynamic behavior of window constructions is imported.<br>
+<sup>4</sup> Only Ruleset and FixedInterval schedules are imported.<br>
+<sup>5</sup> Might be supported in the future depending upon [this issue](https://github.com/NREL/OpenStudio/issues/4469).<br>
+<sup>6</sup> These become divorced from the ProgramType since they are not a part of OpenStudio SpaceTypes.
+
+
 ## Export:
+
+There is no loss of information when exporting to HBJSON and all energy properties are
+included upon export to OSM and IDF. For gbXML, the properties that are exported
+are the same as those which are imported.
 
 * [Export Honeybee JSON \(HBJSON\)](export/hbjson.md)
 * [Export Green Building XML \(gbXML\)](export/gbxml.md)
 * [Export OpenStudio Model \(OSM\) + Input Data File \(IDF\)](export/osm.md)
-


### PR DESCRIPTION
This is what it should look like in the GitBook once we merge this, @jv-ladybugtools .

https://github.com/chriswmackey/pollination-docs/blob/master/rhino-plugin/interoperability/rhino-import-export.md#rhino-importexport